### PR TITLE
Allow strings without template tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
  */
 
 function ject(str, obj) {
-  var keys = str.match(/({{.+?}})/g)
+  var keys = str.match(/({{.+?}})/g) || []
   keys.forEach(function(v, i) {
     var key = keys[i].replace(/{{(.+)}}/, '$1')
     var val = obj[key]

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,10 @@ var ject = require('../')
  */
 
 test('ject(str, obj)', function(assert) {
+  var none = ject('Hello there!', {
+    name: 'anonymous'
+  })
+
   var single = ject('Hello, {{name}}!', {
     name: 'anonymous'
   })
@@ -19,6 +23,7 @@ test('ject(str, obj)', function(assert) {
     name: 'anonymous'
   })
 
+  assert.equal(none, 'Hello there!')
   assert.equal(single, 'Hello, anonymous!')
   assert.equal(multiple, 'Hello, anonymous!')
   assert.end()


### PR DESCRIPTION
If a string without template tags is used for injection, just return the
string as is. Since `String.prototype.match` returns `null` for regexes
with no match, the return value is defaulted to an empty array.
